### PR TITLE
Added ability to limit number of results from scan

### DIFF
--- a/src/cbass/cbass.clj
+++ b/src/cbass/cbass.clj
@@ -49,12 +49,15 @@
              [(row-key-fn (.getRow r)) 
               (hdata->map r)])))
 
-(defn scan [conn table & {:keys [row-key-fn] :as criteria}]
+(defn scan [conn table & {:keys [row-key-fn limit] :as criteria}]
   (with-open [^HTableInterface h-table (get-table conn table)]
     (let [results (-> (.iterator (.getScanner h-table (scan-filter criteria)))
                       iterator-seq)
           row-key-fn (or row-key-fn #(String. %))]
-      (results->map results row-key-fn))))
+      (results->map (if-not limit
+                      results
+                      (take limit results))
+                    row-key-fn))))
 
 (defn find-by
   ([conn table row-key]


### PR DESCRIPTION
Optionally wraps the scan results iterator-seq in a `take` function

(scan conn table :limit 10 ...) will gurantee that at most 10 entities
will come back as a result of the scan
