### PR TITLE
When using limit setCaching on scanner

### DIFF
--- a/src/cbass/scan.clj
+++ b/src/cbass/scan.clj
@@ -23,6 +23,9 @@
 (defn- set-reverse! [^Scan scanner reverse?]
   (.setReversed scanner reverse?))
 
+(defn- set-caching! [^Scan scanner limit]
+  (.setCaching scanner limit))
+
 (defn- add-family [^Scan scanner family]
   (.addFamily scanner (to-bytes family)))
 
@@ -31,13 +34,14 @@
     (.addColumn scanner (to-bytes family) (to-bytes (name c)))))
 
 ;; doing one family many columns for now
-(defn scan-filter [{:keys [family columns starts-with from to time-range reverse?]}]
+(defn scan-filter [{:keys [family columns starts-with from to time-range reverse? limit]}]
   (let [scanner (Scan.)
         {:keys [from-ms to-ms]} time-range
         params [(if (and family (seq columns))
                   [add-columns [family columns]]
                   [add-family family])
                 [set-reverse! reverse?]
+                [set-caching! limit]
                 [set-row-prefix! starts-with]
                 [set-start-row! from]
                 [set-stop-row! to]


### PR DESCRIPTION
The default cache size could be inappropriate for large tables so set
the caching to the limit value
