### PR TITLE
Added a scan that returns a seq.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cbass "0.1.4-SNAPSHOT"
+(defproject cbass "0.1.5-SNAPSHOT"
   :description "adding simple to HBase"
   :url "https://github.com/tolitius/cbass"
   :license {:name "Eclipse Public License"
@@ -11,6 +11,5 @@
                  [com.taoensso/nippy "2.9.0"]
                  [org.clojure/clojure "1.7.0"]]
 
-  :repositories {"cloudera" 
+  :repositories {"cloudera"
                  {:url "https://repository.cloudera.com/artifactory/cloudera-repos"}})
-


### PR DESCRIPTION
I've added a version of scan that returns a lazy sequence of vectors instead of a map. Coercing the results into a map using into forces the whole result set to be realised in memory leading to out of memory errors.

This abstraction of a sequence of vectors makes more sense to me for a scan. A map is great when you want to access the results by key, however a scan tends to return results when you don't know the row keys and therefore a map is not actually as useful as a sequence of vectors. With a sequence of vectors per row you can map over the sequence to carry out actions which in my opinion is more useful.
