### PR TITLE
Made delete-by always lazy to avoid OOM exceptions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cbass "0.1.5-SNAPSHOT"
+(defproject cbass "0.1.6-SNAPSHOT"
   :description "adding simple to HBase"
   :url "https://github.com/tolitius/cbass"
   :license {:name "Eclipse Public License"
@@ -12,6 +12,5 @@
                  [com.taoensso/nippy "2.9.0"]
                  [org.clojure/clojure "1.7.0"]]
 
-  :repositories {"cloudera" 
+  :repositories {"cloudera"
                  {:url "https://repository.cloudera.com/artifactory/cloudera-repos"}})
-

--- a/test/cbass/test.clj
+++ b/test/cbass/test.clj
@@ -3,19 +3,26 @@
             [cbass :refer :all]))
 
 (defn connect []
-  (new-connection {"hbase.zookeeper.quorum" 
-                   "localhost:2181" 
-                   "zookeeper.session.timeout" 
+  (new-connection {"hbase.zookeeper.quorum"
+                   "localhost:2181"
+                   "zookeeper.session.timeout"
                    30000}))
 
 (defn create-solar [conn]
-  (store-batch conn "galaxy:planet" 
+  (store-batch conn "galaxy:planet"
                [["mars" "galaxy" {:inhabited? true :population 3 :age "4.503 billion years"}]
                 ["earth" "galaxy" {:inhabited? true :population 7125000000 :age "4.543 billion years"}]
                 ["pluto" "galaxy"]
                 ["saturn" "galaxy" {:inhabited? :unknown :age "4.503 billion years"}]
                 ["saturday" "galaxy" {:inhabited? :sometimes :age "24 hours"}]
                 ["neptune" "galaxy" {:inhabited? :unknown :age "4.503 billion years"}]]))
+
+(deftest test-delete-by-lazy
+  (with-redefs [scan (fn [_ _ & {:keys [lazy?] :as by}]
+                       (when-not lazy? (is false "Scan is not lazy"))
+                       {})]
+    (is (nil? (delete-by (connect) "galaxy:planet")))
+    (is (nil? (delete-by (connect) "galaxy:planet" :filter nil)))))
 
 ;; hbase(main):010:0* create_namespace 'galaxy';
 ;; hbase(main):011:0* create 'galaxy:planet', 'galaxy';


### PR DESCRIPTION
There's no reason for delete-by to have a fully realised collection in
the intermediary stage of the scan as this is opaque to the user so make
the scan always lazy.
