### PR TITLE
refactor test to mock connection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cbass "0.2.2"
+(defproject cbass "0.2.3-SNAPSHOT"
   :description "adding simple to HBase"
   :url "https://github.com/tolitius/cbass"
   :license {:name "Eclipse Public License"
@@ -6,11 +6,10 @@
 
   :source-paths ["src" "src/cbass"]
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.apache.hbase/hbase-shaded-client "1.4.8"]
                  [aesahaettr "0.1.2"]
-                 [com.taoensso/nippy "2.13.0"]
-                 ]
+                 [com.taoensso/nippy "2.14.0"]]
   :global-vars {*warn-on-reflection* true}
   :aot :all
   :repositories {"cloudera"

--- a/test/cbass/test.clj
+++ b/test/cbass/test.clj
@@ -3,10 +3,11 @@
             [cbass :refer :all]))
 
 (defn connect []
-  (new-connection {"hbase.zookeeper.quorum"
-                   "localhost:2181"
-                   "zookeeper.session.timeout"
-                   30000}))
+  ; for an integration test ... (new-connection {...}))
+  {"hbase.zookeeper.quorum"
+   "localhost:2181"
+   "zookeeper.session.timeout"
+   30000})
 
 (defn create-solar [conn]
   (store-batch conn "galaxy:planet"
@@ -20,7 +21,9 @@
 (deftest test-delete-by-lazy
   (with-redefs [scan (fn [_ _ & {:keys [lazy?] :as by}]
                        (when-not lazy? (is false "Scan is not lazy"))
-                       {})]
+                       {})
+                with-open (fn [])
+                get-table (fn [])]
     (is (nil? (delete-by (connect) "galaxy:planet")))
     (is (nil? (delete-by (connect) "galaxy:planet" :filter nil)))))
 


### PR DESCRIPTION
Refactored so as not to try to connect to zookeeper whenever test were run.

So this was actually very interesting. I was trying to run cloverage across our repo (about 20 clojure projects) and a bunch were failing with a strange exception. I tracked it down to all of the projects that imported cbass. Turns out the core test, which is really in integration test, connection to zookeeper was being executed when cloverage scanned the imported code. The weird thing was that it was complaining about nippy, perhaps it was just the import order.

This just mocks out the connection and the other methods being called by the test to avoid the problem. 

I also bumped the version of nippy and clojure while I was in there.

Thanks!
