### PR TITLE
Remove :aot :all from project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,5 @@
                  [aesahaettr "0.1.2"]
                  [com.taoensso/nippy "2.15.3"]]
   :global-vars {*warn-on-reflection* true}
-  :aot :all
   :repositories {"cloudera"
                  {:url "https://repository.cloudera.com/artifactory/cloudera-repos"}})


### PR DESCRIPTION
This PR addresses #21.
Setting `:aot :all` in `project.clj` causes all the dependencies to be packaged as part of the jar that is uploaded to Clojars. 
This is very annoying for application using `cbass`  that has dependencies in common with `cbass` or with a transitive dependency of `cbass` (e.g taoensso/encore). 
I don't think it's a good practice to package deps inside a lib.