### PR TITLE
Avoid compilation warnings in clojure 1.11

### DIFF
--- a/src/cbass/tools.clj
+++ b/src/cbass/tools.clj
@@ -1,4 +1,5 @@
 (ns cbass.tools
+  (:refer-clojure :exclude [bytes? parse-long])
   (:require [taoensso.nippy :as n]
             [æsahættr :refer [hash-object hash-bytes murmur3-32 murmur3-128]])
   (:import [org.apache.hadoop.hbase.util Bytes]


### PR DESCRIPTION
`bytes?` was added in 1.9, `parse-long` in 1.11


Without this change, every library consumer will see these warnings, every time the namespace is loaded (usually: on REPL startup and during the build process)

```
WARNING: bytes? already refers to: #'clojure.core/bytes? in namespace: cbass.tools, being replaced by: #'cbass.tools/bytes?
WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: cbass.tools, being replaced by: #'cbass.tools/parse-long
```